### PR TITLE
Gitlab compatibility

### DIFF
--- a/content.js
+++ b/content.js
@@ -7,13 +7,13 @@ const SETTINGS_BUTTON_ID_PREFIX = 'cc-settings-button-'; // Prefix for settings 
 // --- Global Selector for Textareas ---
 
 // Selectors for GitHub textareas where the toolbar should appear
-// GitHub selectors
 const TARGET_TEXTAREA_SELECTORS = [
+    // GitHub selectors
     'textarea[name="comment[body]"]',                     // Standard issue/PR comments
     'textarea[name="issue_comment[body]"]',               // Editing existing PR issue comments
     'textarea[name="pull_request_review_comment[body]"]', // Editing existing PR review line comments
     'textarea[name="pull_request_review[body]"]',          // Review Changes modal/popup form
-// GitLab selectors
+    // GitLab selectors
     'textarea[name="note[note]"]',                        // MR discussions (incl. line comments)
     'textarea[name="work-item-add-or-edit-comment"]'      // Issue discussions (incl. new descriptions & comments)
 ];

--- a/content.js
+++ b/content.js
@@ -7,11 +7,15 @@ const SETTINGS_BUTTON_ID_PREFIX = 'cc-settings-button-'; // Prefix for settings 
 // --- Global Selector for Textareas ---
 
 // Selectors for GitHub textareas where the toolbar should appear
+// GitHub selectors
 const TARGET_TEXTAREA_SELECTORS = [
     'textarea[name="comment[body]"]',                     // Standard issue/PR comments
     'textarea[name="issue_comment[body]"]',               // Editing existing PR issue comments
     'textarea[name="pull_request_review_comment[body]"]', // Editing existing PR review line comments
-    'textarea[name="pull_request_review[body]"]'          // Review Changes modal/popup form
+    'textarea[name="pull_request_review[body]"]',          // Review Changes modal/popup form
+// GitLab selectors
+    'textarea[name="note[note]"]',                        // MR discussions (incl. line comments)
+    'textarea[name="work-item-add-or-edit-comment"]'      // Issue discussions (incl. new descriptions & comments)
 ];
 
 // Combine selectors with :not(.cc-toolbar-added) for querying unprocessed textareas

--- a/manifest-base.json
+++ b/manifest-base.json
@@ -7,7 +7,8 @@
     "storage"
   ],
   "host_permissions": [
-    "*://github.com/*"
+    "*://github.com/*",
+    "*://gitlab.com/*"
   ],
   "icons": {
     "16": "icons/icon16.png",
@@ -17,7 +18,8 @@
   "content_scripts": [
     {
       "matches": [
-        "*://github.com/*"
+        "*://github.com/*",
+        "*://gitlab.com/*"
       ],
       "exclude_matches": [ "*://github.com/login*" ],
       "js": ["content.js"],


### PR DESCRIPTION
## 📑 Description

This PR introduces compatibility for the Conventional Comments extension with GitLab

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] I have updated the documentation if required
- [ ] All the CI workflows have passed

## ℹ️ Additional Information

Key changes:
- Updated `manifest-base.json` to include `*://gitlab.com/*` in
  `host_permissions` and `content_scripts.matches`.
- Modified `content.js`:
    - Added comments to distinguish between GitHub and GitLab selectors.
    - Updated GitLab CSS selectors to be more specific:
        - `textarea[name="note[note]"]` (for MR discussions, incl. line comments)
        - `textarea[name="work-item-add-or-edit-comment"]` (for Issue discussions, incl. new Issue descriptions & comments)
