### PR TITLE
fix: avoid event propagation on slack btn click

### DIFF
--- a/src/content/slack-threads.js
+++ b/src/content/slack-threads.js
@@ -117,7 +117,11 @@ function createSlackRedirectButton(url) {
         button.rel = 'noopener noreferrer';
     } else {
         button = document.createElement('button');
-        button.addEventListener('click', () => {
+        button.addEventListener('click', (event) => {
+            // Stop propagation to avoid triggering underlying components
+            event.stopPropagation();
+            event.preventDefault();
+
             // Get organization name from URL for query parameter
             const orgSlug = window.location.pathname.split('/')[1]; // GitHub org slug from URL
             


### PR DESCRIPTION
## 📑 Description

This solves a bug reported by Javi where clicking the Slack thread button on a resolved thread caused it to "unresolve" due to misshandled event propagation.

## ℹ️ Additional Information

There's some minor misalignment styling issues that can be solved in a subsequent PR